### PR TITLE
STRMALERT-1915 - collecting new metrics for clustering feature

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -65,6 +65,11 @@ var (
 	M_StatTotal_Users        Gauge
 	M_StatTotal_Orgs         Gauge
 	M_StatTotal_Playlists    Gauge
+
+	//Clustering
+	M_Clustering_Active_Nodes         Gauge
+	M_Clustering_Pending_Alert_Jobs   Gauge
+	M_Clustering_Missing_Alerts_Count Gauge
 )
 
 func initMetricVars(settings *MetricSettings) {
@@ -138,4 +143,9 @@ func initMetricVars(settings *MetricSettings) {
 	M_StatTotal_Users = RegGauge("stat_totals", "stat", "users")
 	M_StatTotal_Orgs = RegGauge("stat_totals", "stat", "orgs")
 	M_StatTotal_Playlists = RegGauge("stat_totals", "stat", "playlists")
+
+	//Clustering
+	M_Clustering_Active_Nodes = RegGauge("clustering.active_nodes")
+	M_Clustering_Pending_Alert_Jobs = RegGauge("clustering.pending_alert_jobs")
+	M_Clustering_Missing_Alerts_Count = RegGauge("clustering.missing_alerts_count")
 }

--- a/pkg/services/clustering/cluster_manager.go
+++ b/pkg/services/clustering/cluster_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
+	"github.com/grafana/grafana/pkg/metrics"
 	m "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/setting"
@@ -153,6 +154,7 @@ func (cm *ClusterManager) hasPendingAlertJobs() bool {
 		panic(fmt.Sprintf("Failed to get pending alert job count. Error: %v", err))
 	}
 	cm.log.Debug("Cluster manager ticker - pending alert jobs", "count", jobCountQuery.ResultCount)
+	metrics.M_Clustering_Pending_Alert_Jobs.Update(int64(jobCountQuery.ResultCount))
 	return jobCountQuery.ResultCount > 0
 }
 
@@ -164,6 +166,9 @@ func (cm *ClusterManager) checkMissingAlerts() bool {
 		return false
 	}
 	cm.log.Debug("Command to get missing alerts executed successfully")
+
+	metrics.M_Clustering_Missing_Alerts_Count.Update(int64(len((*cmd).Result)))
+	cm.log.Debug(fmt.Sprintf("Count of missing alerts %v", len((*cmd).Result)))
 	//TODO
 	return false
 }
@@ -193,10 +198,13 @@ func (cm *ClusterManager) scheduleNormalAlerts() {
 		return
 	}
 	nodeCount, err := cm.clusterNodeMgmt.GetActiveNodesCount(lastHeartbeat)
+
 	if err != nil {
 		cm.log.Error("Failed to get active node count for heartbeat "+string(lastHeartbeat), "error", err)
 		return
 	}
+	metrics.M_Clustering_Active_Nodes.Update(int64(nodeCount))
+	cm.log.Debug(fmt.Sprintf("Total active nodes as %v", nodeCount))
 	if nodeCount == 0 {
 		cm.log.Warn("Found node count 0")
 		return


### PR DESCRIPTION
* STRMALERT-1915 
Add 3 new metrics to the /metrics/api -> 

"clustering.active_nodes": {
"value": 1
},
"clustering.missing_alerts_count": {
"value": 0
},
"clustering.pending_alert_jobs": {
"value": 0
},


