### PR TITLE
active_node and annotation table cleanup

### DIFF
--- a/pkg/models/active_node.go
+++ b/pkg/models/active_node.go
@@ -12,6 +12,7 @@ type ActiveNode struct {
 
 const (
 	CLN_ALERT_RUN_TYPE_MISSING  = "missing"
+	CLN_ALERT_RUN_TYPE_CLEANUP  = "cleanup"
 	CLN_ALERT_RUN_TYPE_NORMAL   = "normal"
 	CLN_ALERT_STATUS_OFF        = "off"
 	CLN_ALERT_STATUS_READY      = "ready"
@@ -26,9 +27,10 @@ type GetActiveNodeByIdHeartbeatQuery struct {
 }
 
 type SaveActiveNodeCommand struct {
-	Node        *ActiveNode
-	FetchResult bool
-	Result      *ActiveNode
+	Node             *ActiveNode
+	ParticipantLimit int
+	FetchResult      bool
+	Result           *ActiveNode
 }
 
 type SaveNodeProcessingMissingAlertCommand struct {
@@ -53,4 +55,12 @@ type GetActiveNodesCountCommand struct {
 
 type GetNodeProcessingMissingAlertsCommand struct {
 	Result *ActiveNode
+}
+
+type ClusteringCleanupCommand struct {
+	LastHeartbeat int64
+}
+type ClusteringCleanupCheckCommand struct {
+	LastHeartbeat int64
+	Result        bool
 }

--- a/pkg/services/clustering/cluster_manager_test.go
+++ b/pkg/services/clustering/cluster_manager_test.go
@@ -85,7 +85,7 @@ func TestClusterManager(t *testing.T) {
 			// dispatch successful
 			handlers.scheduleAlertsForPartitionErr = nil
 			task := <-cm.dispatcherTaskQ
-			cm.handleAlertRulesDispatcherTask(task)
+			cm.handleDispatcherTask(task)
 			So(len(cm.dispatcherTaskStatus), ShouldEqual, 1)
 			status := <-cm.dispatcherTaskStatus
 			So(status.success, ShouldBeTrue)
@@ -113,7 +113,7 @@ func TestClusterManager(t *testing.T) {
 			// dispatch failed
 			handlers.scheduleAlertsForPartitionErr = errors.New("some error")
 			task = <-cm.dispatcherTaskQ
-			cm.handleAlertRulesDispatcherTask(task)
+			cm.handleDispatcherTask(task)
 			So(len(cm.dispatcherTaskStatus), ShouldEqual, 1)
 			status = <-cm.dispatcherTaskStatus
 			So(status.success, ShouldBeFalse)
@@ -173,7 +173,7 @@ func TestClusterManagerForMissingAlerts(t *testing.T) {
 			// normal alerts dispatch successful
 			handlers.scheduleAlertsForPartitionErr = nil
 			normalTask := <-cm.dispatcherTaskQ
-			cm.handleAlertRulesDispatcherTask(normalTask)
+			cm.handleDispatcherTask(normalTask)
 			So(len(cm.dispatcherTaskStatus), ShouldEqual, 1)
 			status := <-cm.dispatcherTaskStatus
 			cm.handleDispatcherTaskStatus(status)
@@ -190,7 +190,7 @@ func TestClusterManagerForMissingAlerts(t *testing.T) {
 			// missing alerts dispatch successful
 			handlers.scheduleMissingAlertsErr = nil
 			missingAlertTask := <-cm.dispatcherTaskQ
-			cm.handleAlertRulesDispatcherTask(missingAlertTask)
+			cm.handleDispatcherTask(missingAlertTask)
 			missingAlertTaskStatus := <-cm.dispatcherTaskStatus
 			So(missingAlertTaskStatus.success, ShouldBeTrue)
 			So(missingAlertTaskStatus.taskType, ShouldEqual, DISPATCHER_TASK_TYPE_ALERTS_MISSING)
@@ -251,7 +251,7 @@ func (cn *mockClusterNodeMgmt) GetNodeId() (string, error) {
 	cn.callCountGetNodeId++
 	return cn.nodeId, cn.retError
 }
-func (cn *mockClusterNodeMgmt) CheckIn(alertingState *AlertingState) error {
+func (cn *mockClusterNodeMgmt) CheckIn(alertingState *AlertingState, participantLimit int) error {
 	cn.callCountCheckIn++
 	return cn.retError
 }

--- a/pkg/services/clustering/cluster_node_mgmt.go
+++ b/pkg/services/clustering/cluster_node_mgmt.go
@@ -12,7 +12,7 @@ import (
 
 type ClusterNodeMgmt interface {
 	GetNodeId() (string, error)
-	CheckIn(alertingState *AlertingState) error
+	CheckIn(alertingState *AlertingState, participantLimit int) error
 	GetNode(heartbeat int64) (*m.ActiveNode, error)
 	CheckInNodeProcessingMissingAlerts(alertingState *AlertingState) error
 	GetActiveNodesCount(heartbeat int64) (int, error)
@@ -57,7 +57,7 @@ func (node *ClusterNode) GetNodeId() (string, error) {
 	return node.nodeId, nil
 }
 
-func (node *ClusterNode) CheckIn(alertingState *AlertingState) error {
+func (node *ClusterNode) CheckIn(alertingState *AlertingState, participantLimit int) error {
 	if node == nil {
 		return errors.New("Cluster node object is nil")
 	}
@@ -67,7 +67,8 @@ func (node *ClusterNode) CheckIn(alertingState *AlertingState) error {
 			AlertRunType: alertingState.run_type,
 			AlertStatus:  alertingState.status,
 		},
-		FetchResult: false,
+		ParticipantLimit: participantLimit,
+		FetchResult:      false,
 	}
 	node.log.Debug("Sending command ", "SaveActiveNodeCommand:Node", cmd.Node)
 	if err := bus.Dispatch(cmd); err != nil {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -32,12 +32,15 @@ const (
 )
 
 const (
-	DEV                          string = "development"
-	PROD                         string = "production"
-	TEST                         string = "test"
-	DEFAULT_ALERT_EVALTIME_LIMIT int64  = 21600 //time in seconds = 6 hrs
-	DEFAULT_MISSING_ALERT_COUNT  int    = 500
-	DEFAULT_MISSING_ALERTS_DELAY int64  = 600 // 10 mins delay
+	DEV                                    string = "development"
+	PROD                                   string = "production"
+	TEST                                   string = "test"
+	DEFAULT_ALERT_EVALTIME_LIMIT           int64  = 21600 //time in seconds = 6 hrs
+	DEFAULT_MISSING_ALERT_COUNT            int    = 500
+	DEFAULT_MISSING_ALERTS_DELAY           int64  = 600     // 10 mins delay
+	DEFAULT_CLUSTERING_CLEANUP_PERIOD      int    = 86400   // 1 day
+	DEFAULT_CLUSTERING_HB_RETENSION_PERIOD int    = 86400   // 1 day
+	DEFAULT_ANNOTATION_RETENSION_PERIOD    int    = 1209600 // 14 days
 )
 
 var (
@@ -177,6 +180,9 @@ var (
 	MaxAlertEvalTimeLimitInSeconds int64 = DEFAULT_ALERT_EVALTIME_LIMIT
 	MaxMissingAlertCount           int   = DEFAULT_MISSING_ALERT_COUNT
 	DefaultMissingAlertsDelay      int64 = DEFAULT_MISSING_ALERTS_DELAY
+	ClusteringCleanupPeriod        int
+	ClusteringHBRetention          int
+	AnnotationRetention            int
 )
 
 type CommandLineArgs struct {
@@ -588,6 +594,9 @@ func NewConfigContext(args *CommandLineArgs) error {
 	MaxAlertEvalTimeLimitInSeconds = clustering.Key("max_alert_evaltime_limit_seconds").MustInt64(DEFAULT_ALERT_EVALTIME_LIMIT)
 	MaxMissingAlertCount = clustering.Key("max_missing_alert_count").MustInt(DEFAULT_MISSING_ALERT_COUNT)
 	DefaultMissingAlertsDelay = clustering.Key("default_missing_alerts_delay").MustInt64(DEFAULT_MISSING_ALERTS_DELAY)
+	ClusteringCleanupPeriod = clustering.Key("cleanup_period").MustInt(DEFAULT_CLUSTERING_CLEANUP_PERIOD)
+	ClusteringHBRetention = clustering.Key("hb_retention_period").MustInt(DEFAULT_CLUSTERING_HB_RETENSION_PERIOD)
+	AnnotationRetention = clustering.Key("annotation_retention_period").MustInt(DEFAULT_ANNOTATION_RETENSION_PERIOD)
 
 	readSessionConfig()
 	readSmtpSettings()


### PR DESCRIPTION
Reviewer: @sanchitraizada @vkhatale 

Implementation of active_node and annotation tables using cluster manager. Cleanup job will only be scheduled on a single node in the cluster.

Tested locally with 3 node cluster.